### PR TITLE
Make org-show images display only in one buffer

### DIFF
--- a/org/org-show.org
+++ b/org/org-show.org
@@ -443,7 +443,7 @@ That is the end!
       (other-window 1) ; back to slide
       (goto-char (point-min))
       (text-scale-set org-show-text-scale)
-      (org-display-inline-images)
+      (org-remove-inline-images)
       (org-cycle-hide-drawers t)
       (org-show-subtree))
 
@@ -568,6 +568,9 @@ On starting, we want to map the slides so we can get slide numbers for navigatio
   (interactive)
   ;; make slide tag visible again
   (remove-from-invisibility-spec 'slide)
+
+  ;; Redisplay inline images
+  (org-display-inline-images)
 
   ;; reset latex scale
   (plist-put org-format-latex-options :scale org-show-original-latex-scale)


### PR DESCRIPTION
I added two lines that turn off inline image display during org-show and redisplay images once the show is over. The images are still resized and displayed in a temporary buffer during the org-show.
