### PR TITLE
added results:output so that results bloc is not +None on the python …

### DIFF
--- a/org/org-show.org
+++ b/org/org-show.org
@@ -139,7 +139,7 @@ Write some code to generate it, and put it in an emacs-lisp-slide block. org-sho
 #+END_SRC
 ** Code blocks should be runnable and editable                        :slide:
 
-#+BEGIN_SRC python
+#+BEGIN_SRC python results: output
 print 6 + 62
 #+END_SRC
 


### PR DESCRIPTION
When I tried to run the python block


#+BEGIN_SRC python 
print 6+6
#+END_SRC

#+RESULTS:
: None

To get it to run, I added results: output