### PR TITLE
Handle directory names with spaces in jmax.bat

### DIFF
--- a/jmax.bat
+++ b/jmax.bat
@@ -1,1 +1,1 @@
-start %~dp0\emacs\bin\runemacs.exe -l %~dp0\init.el %1
+start "" "%~dp0\emacs\bin\runemacs.exe" -l "%~dp0\init.el" %1


### PR DESCRIPTION
jmax.bat can now be called from a directory that contains a space in its name (i.e. "C:\my dir\jmax"). Fixes #66.