### PR TITLE
ispell skip needs to recognize end of line for org-ref-links

### DIFF
--- a/jmax.el
+++ b/jmax.el
@@ -340,9 +340,9 @@
     (add-to-list 'ispell-skip-region-alist '("~" "~"))
     (add-to-list 'ispell-skip-region-alist '("=" "="))
     ;; this next line approximately ignores org-ref-links
-    (add-to-list 'ispell-skip-region-alist '("cite:" . " "))
-    (add-to-list 'ispell-skip-region-alist '("label:" . " "))
-    (add-to-list 'ispell-skip-region-alist '("ref:" . " "))
+    (add-to-list 'ispell-skip-region-alist '("cite:" . "[[:space:]]"))
+    (add-to-list 'ispell-skip-region-alist '("label:" . "[[:space:]]"))
+    (add-to-list 'ispell-skip-region-alist '("ref:" . "[[:space:]]"))
     (add-to-list 'ispell-skip-region-alist '("^#\\+BEGIN_SRC" . "^#\\+END_SRC")))
 
   (add-hook 'org-mode-hook #'endless/org-ispell)


### PR DESCRIPTION
When org-ref-links are at the end of line there is no space to close the region to be skipped(especially if trailing white-space is deleted. Then the skip region is terminated in the next space. This is problematic if the next space is found after another regex which also marks a region to be skipped.

Without this patch the next example ispell will spellcheck the code block, because the skip region of `cite` was terminated in `#+BEGIN_SRC `. 
```org
like cite:najera2017_resolving_vo2_controversy.

#+BEGIN_SRC python
import numpy

#+END_SRC
```